### PR TITLE
[feat] 댓글 기능, 좋아요 구현 #8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.data:spring-data-jpa'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/newspeed/newspeed/NewspeedApplication.java
+++ b/src/main/java/com/newspeed/newspeed/NewspeedApplication.java
@@ -2,10 +2,11 @@ package com.newspeed.newspeed;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class NewspeedApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(NewspeedApplication.class, args);
 	}

--- a/src/main/java/com/newspeed/newspeed/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/newspeed/newspeed/common/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.newspeed.newspeed.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/newspeed/newspeed/domain/comments/controller/CommentController.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/controller/CommentController.java
@@ -1,0 +1,71 @@
+package com.newspeed.newspeed.domain.comments.controller;
+
+import com.newspeed.newspeed.domain.comments.dto.request.CommentRequestDto;
+import com.newspeed.newspeed.domain.comments.dto.request.UpdateCommentRequestDto;
+import com.newspeed.newspeed.domain.comments.dto.response.CommentResponseDto;
+import com.newspeed.newspeed.domain.comments.entity.Comment;
+import com.newspeed.newspeed.domain.comments.service.CommentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<List<CommentResponseDto>> getCommentsByPostId(@PathVariable Long postId) {
+        List<CommentResponseDto> comments = commentService.getCommentsByPostId(postId);
+        return new ResponseEntity<>(comments, HttpStatus.OK);
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createComment(
+            @RequestParam Long userId,
+            @RequestParam Long postId,
+            @Valid @RequestBody CommentRequestDto requestDto) {
+        Comment comment = commentService.createComment(userId, postId, requestDto);
+
+        return new ResponseEntity<>(comment, HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{commentId}")
+    public ResponseEntity<?> updateComment(
+            @PathVariable Long commentId,
+            @RequestParam("userId") Long userId,
+            @RequestBody UpdateCommentRequestDto requestDto) {
+        commentService.updateComment(userId, commentId, requestDto);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<?> deleteComment(
+            @PathVariable Long commentId,
+            @RequestParam("userId") Long userId) {
+        commentService.deleteComment(userId, commentId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @PostMapping("/{commentId}/like")
+    public ResponseEntity<?> addCommentLike(
+            @PathVariable Long commentId,
+            @RequestParam("userId") Long userId) {
+        commentService.addCommentLike(userId, commentId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{commentId}/like")
+    public ResponseEntity<?> removeCommentLike(
+            @PathVariable Long commentId,
+            @RequestParam("userId") Long userId) {
+        commentService.removeCommentLike(userId, commentId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/newspeed/newspeed/domain/comments/dto/Response/CommentResponseDto.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/dto/Response/CommentResponseDto.java
@@ -1,0 +1,23 @@
+package com.newspeed.newspeed.domain.comments.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+// 댓글 조회 반환 DTO
+public class CommentResponseDto {
+    private Long commentId; // 댓글 ID
+
+    private Long postId; // 게시글 ID
+
+    private Long userId; // 작성자 ID
+
+    private String username; // 작성자 이름
+
+    private String commentText; // 댓글 내용
+
+    private Integer commentLikes; // 댓글 좋아요 갯수
+}

--- a/src/main/java/com/newspeed/newspeed/domain/comments/dto/request/CommentRequestDto.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/dto/request/CommentRequestDto.java
@@ -1,0 +1,13 @@
+package com.newspeed.newspeed.domain.comments.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Valid
+@Data
+// 댓글 작성 요청 DTO
+public class CommentRequestDto {
+    @NotNull(message = "댓글 내용은 필수입니다.")
+    private String commentText; // 댓글
+}

--- a/src/main/java/com/newspeed/newspeed/domain/comments/dto/request/DeleteCommentRequestDto.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/dto/request/DeleteCommentRequestDto.java
@@ -1,0 +1,13 @@
+package com.newspeed.newspeed.domain.comments.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Valid
+@Data
+// 댓글 삭제 요청 DTO
+public class DeleteCommentRequestDto {
+    @NotNull(message = "댓글 ID는 필수입니다.")
+    private Long commentId; // 댓글 ID
+}

--- a/src/main/java/com/newspeed/newspeed/domain/comments/dto/request/UpdateCommentRequestDto.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/dto/request/UpdateCommentRequestDto.java
@@ -1,0 +1,16 @@
+package com.newspeed.newspeed.domain.comments.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Valid
+@Data
+// 댓글 수정 요청 DTO
+public class UpdateCommentRequestDto {
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(min = 1, max = 500, message = "댓글 내용은 1자 이상 500자 이하로 입력해야 합니다.")
+    private String commentText; // 댓글
+}
+

--- a/src/main/java/com/newspeed/newspeed/domain/comments/entity/Comment.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/entity/Comment.java
@@ -1,0 +1,40 @@
+package com.newspeed.newspeed.domain.comments.entity;
+
+import com.newspeed.newspeed.common.entity.BaseTimeEntity;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "Comment")
+@Data
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class Comment extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Column(name = "text", columnDefinition = "TEXT")
+    private String commentText;
+
+    @Column(name = "likes", columnDefinition = "INT DEFAULT 0", nullable = false)
+    private Integer commentLikes;
+
+    // 생성자 추가
+    public Comment(User user, Post post, String commentText) {
+        this.user = user;
+        this.post = post;
+        this.commentText = commentText;
+    }
+}

--- a/src/main/java/com/newspeed/newspeed/domain/comments/entity/CommentLike.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/entity/CommentLike.java
@@ -1,0 +1,34 @@
+package com.newspeed.newspeed.domain.comments.entity;
+
+import com.newspeed.newspeed.common.entity.BaseTimeEntity;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+
+@Entity
+@Table(name = "comment_like")
+@Data
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class CommentLike extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    public CommentLike(User user, Comment comment) {
+        this.user = user;
+        this.comment = comment;
+    }
+}
+

--- a/src/main/java/com/newspeed/newspeed/domain/comments/entity/Post.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/entity/Post.java
@@ -1,0 +1,32 @@
+package com.newspeed.newspeed.domain.comments.entity;
+
+import com.newspeed.newspeed.common.entity.BaseTimeEntity;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.*;
+
+
+@Entity
+@Table(name = "Post")
+@Data
+@NoArgsConstructor
+public class Post extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "text", columnDefinition = "TEXT")
+    private String postText;
+
+    @Column(name = "image", length = 500)
+    private String image;
+
+    @Column(name = "likes", columnDefinition = "INT DEFAULT 0")
+    private Integer commentLikes;
+}
+

--- a/src/main/java/com/newspeed/newspeed/domain/comments/entity/User.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/entity/User.java
@@ -1,0 +1,27 @@
+package com.newspeed.newspeed.domain.comments.entity;
+
+import com.newspeed.newspeed.common.entity.BaseTimeEntity;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import jakarta.persistence.*;
+
+
+@Entity
+@Table(name = "User")
+@Data
+@NoArgsConstructor
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "email", nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+}

--- a/src/main/java/com/newspeed/newspeed/domain/comments/repository/CommentLikeRepository.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/repository/CommentLikeRepository.java
@@ -1,0 +1,10 @@
+package com.newspeed.newspeed.domain.comments.repository;
+
+import com.newspeed.newspeed.domain.comments.entity.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    void deleteByComment_IdAndUser_Id(Long commentId, Long userId);
+    boolean existsByComment_IdAndUser_Id(Long commentId, Long userId);
+}
+

--- a/src/main/java/com/newspeed/newspeed/domain/comments/repository/CommentRepository.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/repository/CommentRepository.java
@@ -1,0 +1,25 @@
+package com.newspeed.newspeed.domain.comments.repository;
+
+import com.newspeed.newspeed.domain.comments.dto.response.CommentResponseDto;
+import com.newspeed.newspeed.domain.comments.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("SELECT " +
+            "new com.newspeed.newspeed.domain.comments.dto.response.CommentResponseDto(" +
+            "c.id, " +
+            "c.post.id, " +
+            "u.id, " +
+            "u.name, " +
+            "c.commentText, " +
+            "c.commentLikes) " +
+            "FROM Comment c " +
+            "JOIN c.user u " +
+            "WHERE c.post.id = :postId " +
+            "ORDER BY c.id DESC")
+    List<CommentResponseDto> findCommentResponseDtoByPostId(@Param("postId") Long postId);
+}

--- a/src/main/java/com/newspeed/newspeed/domain/comments/repository/PostRepository.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package com.newspeed.newspeed.domain.comments.repository;
+
+import com.newspeed.newspeed.domain.comments.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    Optional<Post> findById(Long id);
+}

--- a/src/main/java/com/newspeed/newspeed/domain/comments/repository/UserRepository.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.newspeed.newspeed.domain.comments.repository;
+
+import com.newspeed.newspeed.domain.comments.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findById(Long id);
+}

--- a/src/main/java/com/newspeed/newspeed/domain/comments/service/CommentService.java
+++ b/src/main/java/com/newspeed/newspeed/domain/comments/service/CommentService.java
@@ -1,0 +1,148 @@
+package com.newspeed.newspeed.domain.comments.service;
+
+import com.newspeed.newspeed.domain.comments.dto.request.*;
+import com.newspeed.newspeed.domain.comments.dto.response.CommentResponseDto;
+import com.newspeed.newspeed.domain.comments.entity.*;
+import com.newspeed.newspeed.domain.comments.repository.*;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    // 댓글 전체 조회
+    public List<CommentResponseDto> getCommentsByPostId(Long postId) {
+        return commentRepository.findCommentResponseDtoByPostId(postId);
+    }
+
+    @Transactional
+    // 댓글 생성
+    public Comment createComment(Long userId, Long postId, CommentRequestDto requestDto) {
+            // 1. 사용자 인증 및 게시글 존재 확인
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+            Post post = postRepository.findById(postId)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+            // 2. 댓글 생성
+            Comment comment = new Comment(user, post, requestDto.getCommentText());
+            comment.setCommentLikes(0); // 좋아요 개수 0 초기화
+
+            // 3. 댓글 저장
+            return commentRepository.save(comment);
+    }
+
+
+    @Transactional
+    // 댓글 수정
+    public void updateComment(Long userId, Long commentId, UpdateCommentRequestDto requestDto) {
+        // 1. 사용자 인증 및 댓글 존재 확인
+        userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        // 2. 댓글 작성자인지 확인
+        if (!isCommentOwner(userId, comment)) {
+            throw new IllegalArgumentException("댓글 작성자가 아닙니다.");
+        }
+
+        // 3. 댓글 내용 수정
+        comment.setCommentText(requestDto.getCommentText());
+
+        // 4. 변경 사항 저장
+        commentRepository.save(comment);
+    }
+
+    @Transactional
+    // 댓글 삭제
+    public void deleteComment(Long userId, Long commentId) {
+        // 1. 사용자 인증 및 댓글 존재 확인
+        userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        // 2. 게시글 작성자 또는 댓글 작성자인지 확인
+        if (!isPostOwner(userId, comment.getPost().getId()) && !isCommentOwner(userId, comment)) {
+            throw new IllegalArgumentException("게시글 작성자 및 댓글 작성자가 아닙니다.");
+        }
+
+        // 3. 댓글 삭제
+        commentRepository.delete(comment);
+    }
+
+    @Transactional
+    // 댓글 좋아요
+    public void addCommentLike(Long userId, Long commentId) {
+        // 1. 사용자 인증 및 댓글 존재 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        if (commentLikeRepository.existsByComment_IdAndUser_Id(commentId, userId)) {
+            throw new IllegalStateException("이미 좋아요를 누른 댓글입니다.");
+        }
+
+        // 2. 좋아요
+        CommentLike commentLike = new CommentLike(user, comment);
+
+        // 3. 좋아요 저장
+        commentLikeRepository.save(commentLike);
+
+        // 4. Comment 엔티티의 commentLikes 값 증가
+        comment.setCommentLikes(comment.getCommentLikes() + 1);
+    }
+
+    @Transactional
+    // 댓글 좋아요 취소
+    public void removeCommentLike(Long userId, Long commentId) {
+        // 1. 사용자 인증 및 댓글 존재 확인
+        userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        // 2. 댓글 좋아요 유무 확인
+        if (!commentLikeRepository.existsByComment_IdAndUser_Id(userId, commentId)) {
+            throw new IllegalStateException("좋아요를 누르지 않은 댓글입니다.");
+        }
+
+        // 3. 좋아요 삭제
+        commentLikeRepository.deleteByComment_IdAndUser_Id(userId, commentId);
+
+        // 4. Comment 엔티티의 commentLikes 값 감소
+        comment.setCommentLikes(comment.getCommentLikes() - 1);
+    }
+
+    // 게시글 작성자인지 확인하는 메서드
+    private boolean isPostOwner(Long userId, Long postId) {
+        Optional<Post> postOptional = postRepository.findById(postId);
+        if (postOptional.isPresent()) {
+            Post post = postOptional.get();
+            return post.getUser().getId().equals(userId);
+        }
+        return false;
+    }
+
+    // 댓글 작성자인지 확인하는 메서드
+    private boolean isCommentOwner(Long userId, Comment comment) {
+        return comment.getUser().getId().equals(userId);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #8 

---

## ✨ 기능 요약
| 항목 | 내용 |
|------|------|
| 🆕 댓글 기능 | 게시글에 댓글을 작성, 수정, 삭제할 수 있는 기능 |
| 🆕 댓글 좋아요 기능 | 댓글에 좋아요를 누르고 취소할 수 있는 기능 |
| 🛠️ 변경사항 예정 | userId param으로 받아오는 것을 세션으로 교체 |

## 📝 상세 내역

| 번호 | 내용 |
|------|------|
| 1️⃣ | 댓글 CRUD (Create, Read, Update, Delete) 기능을 구현했습니다. 사용자는 게시글에 댓글을 작성하고, 자신의 댓글을 수정하거나 삭제할 수 있습니다. 댓글 작성 시 사용자 인증 및 게시글 존재 여부를 확인합니다. |
| 2️⃣ | 댓글 좋아요/취소 기능을 구현했습니다. 사용자는 댓글에 좋아요를 누르거나 취소할 수 있습니다. 좋아요/취소 시 사용자 인증, 댓글 존재 여부, 이미 좋아요를 눌렀는지 여부를 확인합니다. |
| 3️⃣ | 댓글과 좋아요 기능을 위한 Entity (Comment, CommentLike), Repository (CommentRepository, CommentLikeRepository), Service (CommentService)를 추가했습니다. |
| 4️⃣ | CommentService에 댓글 작성자 확인 (isCommentOwner), 게시글 작성자 확인 (isPostOwner) 메서드를 추가했습니다. |
| 5️⃣ | 존재하지 않는 사용자, 게시글, 댓글에 대한 예외 처리 및 좋아요 중복/미존재에 대한 예외 처리를 추가했습니다. |
| 6️⃣	| 댓글 생성 시 좋아요 개수를 0으로 초기화합니다. |
| 7️⃣	| 댓글 삭제 시 게시글 작성자 또는 댓글 작성자만 삭제할 수 있도록 권한을 확인합니다. |
| 8️⃣	| 댓글 좋아요 시 Comment 엔티티의 commentLikes 값을 증가시키고, 좋아요 취소 시 감소시킵니다. |

## ✅ 테스트 체크리스트
- [x] 댓글 작성, 수정, 삭제 기능 정상 작동 확인
- [x] 댓글 좋아요/취소 기능 정상 작동 확인
- [x] 댓글 좋아요 수 증가/감소 정상 작동 확인
- [x] 존재하지 않는 사용자, 게시글, 댓글에 대한 예외 처리 확인
- [x] 좋아요 중복/미존재에 대한 예외 처리 확인
- [x] 댓글 삭제 시 권한 확인 로직 정상 작동 확인
- [ ]  단위 테스트 코드 작성 (추후 추가 예정)
- [ ] 로그인 세션 확인 (추후 추가 예정)
- [x]  API 연동 확인 (요청/응답 정상 동작) 



## 📸 포스트맨 캡처 사진
댓글 전체 조회 시
![1](https://github.com/user-attachments/assets/31981728-ba4a-43c4-b965-2c76eb95fc13)
댓글 생성 시(자신 게시글에 자신 댓글을 달았지만 다른 회원도 동일합니다.)
![2](https://github.com/user-attachments/assets/b1c45534-7288-4b6f-bc98-66166520498c)
댓글 수정 시(...)
![3](https://github.com/user-attachments/assets/b3f53976-1312-4b70-bc4d-1e42270f0e8a)
댓글 삭제 시(게시글 작성자와 댓글 작성자만 삭제 가능합니다.)
![4](https://github.com/user-attachments/assets/5c8e534f-864e-4881-b4a0-335f0b2f9ea9)
댓글 좋아요(자신 댓글, 다른 회원의 댓글 같은 기능합니다.)
![5](https://github.com/user-attachments/assets/b76ff266-5ef2-4abb-9ec2-3d9917770ce1)
댓글 좋아요 취소(...)
![6](https://github.com/user-attachments/assets/926ce1ec-11d0-4be2-bc86-61b56658b4d9)


## 🙋‍♀️ 리뷰어 참고사항
주요 로직 설명:
- CommentService는 댓글 CRUD 및 좋아요/취소 기능을 담당합니다.
- isCommentOwner, isPostOwner 메서드는 댓글/게시글 작성자 권한을 확인합니다.
- 각 메서드에서 사용자 인증, 댓글/게시글 존재 여부, 권한 등을 확인하고, 예외 발생 시 적절한 예외를 콘솔에 던집니다.

리뷰 시 중점적으로 봐주셨으면 하는 부분:
- 추가 조건 예외 사항이 있을지 간단하게 확인해주시면 감사하겠습니다.
