### PR TITLE
[feat] 친구 관련 API 구현 #7

### DIFF
--- a/src/main/java/com/newspeed/newspeed/NewspeedApplication.java
+++ b/src/main/java/com/newspeed/newspeed/NewspeedApplication.java
@@ -2,8 +2,10 @@ package com.newspeed.newspeed;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class NewspeedApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/newspeed/newspeed/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/newspeed/newspeed/common/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.newspeed.newspeed.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/newspeed/newspeed/common/exception/code/enums/SuccessCode.java
+++ b/src/main/java/com/newspeed/newspeed/common/exception/code/enums/SuccessCode.java
@@ -14,8 +14,8 @@ public enum SuccessCode {
 
     // 200 Ok
     GENERAL_SUCCESS(HttpStatus.OK, "테스트에 성공했습니다."),
-    USER_LOGIN_SUCCESS(HttpStatus.OK, "로그인이 완료되었습니다.");
-
+    USER_LOGIN_SUCCESS(HttpStatus.OK, "로그인이 완료되었습니다."),
+    HANDLE_FRIEND_SUCCESS(HttpStatus.OK, "친구 요청에 대한 응답이 완료되었습니다");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/newspeed/newspeed/common/exception/code/enums/SuccessCode.java
+++ b/src/main/java/com/newspeed/newspeed/common/exception/code/enums/SuccessCode.java
@@ -16,7 +16,8 @@ public enum SuccessCode {
     GENERAL_SUCCESS(HttpStatus.OK, "테스트에 성공했습니다."),
     USER_LOGIN_SUCCESS(HttpStatus.OK, "로그인이 완료되었습니다."),
     HANDLE_FRIEND_SUCCESS(HttpStatus.OK, "친구 요청에 대한 응답이 완료되었습니다"),
-    GET_FRIENDSHIPS_SUCCESS(HttpStatus.OK, "친구 목록 조회가 성공하였습니다");
+    GET_FRIENDSHIPS_SUCCESS(HttpStatus.OK, "친구 목록 조회가 성공하였습니다"),
+    GET_FRIENDSHIPREQUESTS_SUCCESS(HttpStatus.OK, "친구 요청 목록 조회가 성공하였습니다");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/newspeed/newspeed/common/exception/code/enums/SuccessCode.java
+++ b/src/main/java/com/newspeed/newspeed/common/exception/code/enums/SuccessCode.java
@@ -10,6 +10,7 @@ public enum SuccessCode {
 
     // 201 Created
     USER_SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입이 완료되었습니다."),
+    REQUEST_FRIEND_SUCCESS(HttpStatus.CREATED, "친구 요청이 완료되었습니다"),
 
     // 200 Ok
     GENERAL_SUCCESS(HttpStatus.OK, "테스트에 성공했습니다."),

--- a/src/main/java/com/newspeed/newspeed/common/exception/code/enums/SuccessCode.java
+++ b/src/main/java/com/newspeed/newspeed/common/exception/code/enums/SuccessCode.java
@@ -15,7 +15,9 @@ public enum SuccessCode {
     // 200 Ok
     GENERAL_SUCCESS(HttpStatus.OK, "테스트에 성공했습니다."),
     USER_LOGIN_SUCCESS(HttpStatus.OK, "로그인이 완료되었습니다."),
-    HANDLE_FRIEND_SUCCESS(HttpStatus.OK, "친구 요청에 대한 응답이 완료되었습니다");
+    HANDLE_FRIEND_SUCCESS(HttpStatus.OK, "친구 요청에 대한 응답이 완료되었습니다"),
+    GET_FRIENDSHIPS_SUCCESS(HttpStatus.OK, "친구 목록 조회가 성공하였습니다");
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/controller/FriendShipController.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/controller/FriendShipController.java
@@ -1,0 +1,27 @@
+package com.newspeed.newspeed.domain.friendships.controller;
+
+import com.newspeed.newspeed.common.exception.code.enums.SuccessCode;
+import com.newspeed.newspeed.common.response.ApiResponseDto;
+import com.newspeed.newspeed.domain.friendships.dto.request.SendFriendShipRequest;
+import com.newspeed.newspeed.domain.friendships.service.FriendShipService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import static com.newspeed.newspeed.common.exception.code.enums.SuccessCode.REQUEST_FRIEND_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/friendships")
+public class FriendShipController {
+
+    private final FriendShipService friendShipService;
+
+    @PostMapping
+    public ApiResponseDto<Void> sendRequest(@RequestBody @Validated SendFriendShipRequest request) {
+        //todo: 로그인 내용 Pull 이후 세션으로부터 유저 ID를 받아오는 로직 필요
+        Long userId = 1L;
+        friendShipService.sendRequest(request,userId);
+        return ApiResponseDto.success(REQUEST_FRIEND_SUCCESS, "/api/friendships");
+    }
+}

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/controller/FriendShipController.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/controller/FriendShipController.java
@@ -30,7 +30,7 @@ public class FriendShipController {
     }
 
     @PatchMapping("/{requestId}")
-    public ApiResponseDto<Void> handleRequest(@PathVariable Long requestId, @RequestBody @Validated HandleFriendShipRequest request) {
+    public ApiResponseDto<Void> handleRequest(@PathVariable(name = "requestId") Long requestId, @RequestBody @Validated HandleFriendShipRequest request) {
         //todo: 로그인 내용 Pull 이후 세션으로부터 유저 ID를 받아오는 로직 필요
         Long userId = 1L;
         friendShipService.handleRequest(userId, requestId, request);

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/controller/FriendShipController.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/controller/FriendShipController.java
@@ -3,6 +3,7 @@ package com.newspeed.newspeed.domain.friendships.controller;
 import com.newspeed.newspeed.common.response.ApiResponseDto;
 import com.newspeed.newspeed.domain.friendships.dto.request.HandleFriendShipRequest;
 import com.newspeed.newspeed.domain.friendships.dto.request.SendFriendShipRequest;
+import com.newspeed.newspeed.domain.friendships.dto.response.GetFriendShipRequestsResponse;
 import com.newspeed.newspeed.domain.friendships.dto.response.GetFriendShipsResponse;
 import com.newspeed.newspeed.domain.friendships.service.FriendShipService;
 import lombok.RequiredArgsConstructor;
@@ -44,5 +45,11 @@ public class FriendShipController {
         return ApiResponseDto.success(GET_FRIENDSHIPS_SUCCESS, response,"/api/friendships");
     }
 
-
+    @GetMapping("/requests")
+    public ApiResponseDto<GetFriendShipRequestsResponse> getFriendshipRequests(@PageableDefault(size = 10, page = 0) Pageable pageable) {
+        //todo: 로그인 내용 Pull 이후 세션으로부터 유저 ID를 받아오는 로직 필요
+        Long userId = 1L;
+        GetFriendShipRequestsResponse response = friendShipService.getFriendshipRequests(userId, pageable);
+        return ApiResponseDto.success(GET_FRIENDSHIPREQUESTS_SUCCESS, response,"/api/friendships/requests");
+    }
 }

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/controller/FriendShipController.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/controller/FriendShipController.java
@@ -1,16 +1,17 @@
 package com.newspeed.newspeed.domain.friendships.controller;
 
-import com.newspeed.newspeed.common.exception.code.enums.SuccessCode;
 import com.newspeed.newspeed.common.response.ApiResponseDto;
 import com.newspeed.newspeed.domain.friendships.dto.request.HandleFriendShipRequest;
 import com.newspeed.newspeed.domain.friendships.dto.request.SendFriendShipRequest;
+import com.newspeed.newspeed.domain.friendships.dto.response.GetFriendShipsResponse;
 import com.newspeed.newspeed.domain.friendships.service.FriendShipService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import static com.newspeed.newspeed.common.exception.code.enums.SuccessCode.HANDLE_FRIEND_SUCCESS;
-import static com.newspeed.newspeed.common.exception.code.enums.SuccessCode.REQUEST_FRIEND_SUCCESS;
+import static com.newspeed.newspeed.common.exception.code.enums.SuccessCode.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,4 +35,14 @@ public class FriendShipController {
         friendShipService.handleRequest(userId, requestId, request);
         return ApiResponseDto.success(HANDLE_FRIEND_SUCCESS, "/api/friendships");
     }
+
+    @GetMapping
+    public ApiResponseDto<GetFriendShipsResponse> getFriendships(@PageableDefault(size = 10, page = 0) Pageable pageable) {
+        //todo: 로그인 내용 Pull 이후 세션으로부터 유저 ID를 받아오는 로직 필요
+        Long userId = 1L;
+        GetFriendShipsResponse response = friendShipService.getFriendships(userId, pageable);
+        return ApiResponseDto.success(GET_FRIENDSHIPS_SUCCESS, response,"/api/friendships");
+    }
+
+
 }

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/controller/FriendShipController.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/controller/FriendShipController.java
@@ -2,12 +2,14 @@ package com.newspeed.newspeed.domain.friendships.controller;
 
 import com.newspeed.newspeed.common.exception.code.enums.SuccessCode;
 import com.newspeed.newspeed.common.response.ApiResponseDto;
+import com.newspeed.newspeed.domain.friendships.dto.request.HandleFriendShipRequest;
 import com.newspeed.newspeed.domain.friendships.dto.request.SendFriendShipRequest;
 import com.newspeed.newspeed.domain.friendships.service.FriendShipService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import static com.newspeed.newspeed.common.exception.code.enums.SuccessCode.HANDLE_FRIEND_SUCCESS;
 import static com.newspeed.newspeed.common.exception.code.enums.SuccessCode.REQUEST_FRIEND_SUCCESS;
 
 @RestController
@@ -23,5 +25,13 @@ public class FriendShipController {
         Long userId = 1L;
         friendShipService.sendRequest(request,userId);
         return ApiResponseDto.success(REQUEST_FRIEND_SUCCESS, "/api/friendships");
+    }
+
+    @PatchMapping("/{requestId}")
+    public ApiResponseDto<Void> handleRequest(@PathVariable Long requestId, @RequestBody @Validated HandleFriendShipRequest request) {
+        //todo: 로그인 내용 Pull 이후 세션으로부터 유저 ID를 받아오는 로직 필요
+        Long userId = 1L;
+        friendShipService.handleRequest(userId, requestId, request);
+        return ApiResponseDto.success(HANDLE_FRIEND_SUCCESS, "/api/friendships");
     }
 }

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/dto/request/HandleFriendShipRequest.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/dto/request/HandleFriendShipRequest.java
@@ -1,0 +1,7 @@
+package com.newspeed.newspeed.domain.friendships.dto.request;
+
+import com.newspeed.newspeed.domain.friendships.entity.value.Status;
+import jakarta.validation.constraints.NotNull;
+
+public record HandleFriendShipRequest(@NotNull Status status) {
+}

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/dto/request/SendFriendShipRequest.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/dto/request/SendFriendShipRequest.java
@@ -1,0 +1,6 @@
+package com.newspeed.newspeed.domain.friendships.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SendFriendShipRequest(@NotNull Long targetUserId) {
+}

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/dto/response/FriendSummary.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/dto/response/FriendSummary.java
@@ -1,0 +1,6 @@
+package com.newspeed.newspeed.domain.friendships.dto.response;
+
+public record FriendSummary (
+    Integer friendId,
+    String  friendName
+) { }

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/dto/response/FriendSummary.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/dto/response/FriendSummary.java
@@ -1,6 +1,7 @@
 package com.newspeed.newspeed.domain.friendships.dto.response;
 
 public record FriendSummary (
-    Integer friendId,
-    String  friendName
-) { }
+        Long id,
+        String name
+) {
+}

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/dto/response/GetFriendShipRequestsResponse.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/dto/response/GetFriendShipRequestsResponse.java
@@ -1,0 +1,13 @@
+package com.newspeed.newspeed.domain.friendships.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GetFriendShipRequestsResponse (
+        List<FriendSummary> friends,
+        Integer totalPageCount,
+        Long totalElementCount
+) {
+}

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/dto/response/GetFriendShipsResponse.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/dto/response/GetFriendShipsResponse.java
@@ -1,0 +1,13 @@
+package com.newspeed.newspeed.domain.friendships.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GetFriendShipsResponse (
+        List<FriendSummary> friends,
+        Integer totalPageCount,
+        Long totalElementCount
+) {
+}

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/entity/Friendship.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/entity/Friendship.java
@@ -3,6 +3,7 @@ package com.newspeed.newspeed.domain.friendships.entity;
 import com.newspeed.newspeed.domain.users.entity.User;
 import com.newspeed.newspeed.domain.friendships.entity.value.Status;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,4 +41,8 @@ public class Friendship {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    public void updateStatus(Status status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/entity/Friendship.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/entity/Friendship.java
@@ -1,24 +1,20 @@
 package com.newspeed.newspeed.domain.friendships.entity;
 
+import com.newspeed.newspeed.common.entity.BaseTimeEntity;
 import com.newspeed.newspeed.domain.users.entity.User;
 import com.newspeed.newspeed.domain.friendships.entity.value.Status;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Friendship {
+public class Friendship extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,14 +29,6 @@ public class Friendship {
 
     @Enumerated(EnumType.STRING)
     private Status status;
-
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
 
     public void updateStatus(Status status) {
         this.status = status;

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/entity/Friendship.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/entity/Friendship.java
@@ -1,0 +1,43 @@
+package com.newspeed.newspeed.domain.friendships.entity;
+
+import com.newspeed.newspeed.domain.users.entity.User;
+import com.newspeed.newspeed.domain.friendships.entity.value.Status;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Friendship {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follow_to_id")
+    private User followTo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follow_from_id")
+    private User followFrom;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/entity/value/Status.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/entity/value/Status.java
@@ -1,0 +1,5 @@
+package com.newspeed.newspeed.domain.friendships.entity.value;
+
+public enum Status {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/repository/FriendshipRepository.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/repository/FriendshipRepository.java
@@ -1,0 +1,12 @@
+package com.newspeed.newspeed.domain.friendships.repository;
+
+import com.newspeed.newspeed.domain.friendships.entity.Friendship;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface FriendshipRepository extends JpaRepository<Friendship,Long> {
+    @Query("SELECT f FROM Friendship f WHERE f.followFrom.id = :userId AND f.followTo.id = :friendId")
+    Optional<Friendship> findByUserAndFriendId(Long userId, Long friendId);
+}

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/repository/FriendshipRepository.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/repository/FriendshipRepository.java
@@ -1,18 +1,18 @@
 package com.newspeed.newspeed.domain.friendships.repository;
 
 import com.newspeed.newspeed.domain.friendships.dto.response.FriendSummary;
-import com.newspeed.newspeed.domain.friendships.dto.response.GetFriendShipsResponse;
 import com.newspeed.newspeed.domain.friendships.entity.Friendship;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface FriendshipRepository extends JpaRepository<Friendship,Long> {
     @Query("SELECT f FROM Friendship f WHERE f.followFrom.userId = :userId AND f.followTo.userId = :friendId")
-    Optional<Friendship> findByUserAndFriendId(Long userId, Long friendId);
+    Optional<Friendship> findByUserAndFriendId(@Param("userId") Long userId, @Param("friendId") Long friendId);
 
     @Query("""
                 SELECT new com.newspeed.newspeed.domain.friendships.dto.response.FriendSummary(
@@ -29,7 +29,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship,Long> {
                 WHERE f.status = 'ACCEPTED'
                   AND (f.followFrom.userId = :userId OR f.followTo.userId = :userId)
             """)
-    Page<FriendSummary> findAcceptedByConditions(Long userId, Pageable pageable);
+    Page<FriendSummary> findAcceptedByConditions(@Param("userId") Long userId, Pageable pageable);
 
     @Query("""
                 SELECT new com.newspeed.newspeed.domain.friendships.dto.response.FriendSummary(
@@ -46,5 +46,5 @@ public interface FriendshipRepository extends JpaRepository<Friendship,Long> {
                 WHERE f.status = 'PENDING'
                   AND (f.followFrom.userId = :userId OR f.followTo.userId = :userId)
             """)
-    Page<FriendSummary> findPendingByConditions(Long userId, Pageable pageable);
+    Page<FriendSummary> findPendingByConditions(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/repository/FriendshipRepository.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/repository/FriendshipRepository.java
@@ -30,4 +30,21 @@ public interface FriendshipRepository extends JpaRepository<Friendship,Long> {
                   AND (f.followFrom.userId = :userId OR f.followTo.userId = :userId)
             """)
     Page<FriendSummary> findAcceptedByConditions(Long userId, Pageable pageable);
+
+    @Query("""
+                SELECT new com.newspeed.newspeed.domain.friendships.dto.response.FriendSummary(
+                    CASE 
+                        WHEN f.followFrom.userId = :userId THEN f.followTo.userId
+                        ELSE f.followFrom.userId
+                    END,
+                    CASE 
+                        WHEN f.followFrom.userId = :userId THEN f.followTo.name
+                        ELSE f.followFrom.name
+                    END
+                )
+                FROM Friendship f
+                WHERE f.status = 'PENDING'
+                  AND (f.followFrom.userId = :userId OR f.followTo.userId = :userId)
+            """)
+    Page<FriendSummary> findPendingByConditions(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/repository/FriendshipRepository.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/repository/FriendshipRepository.java
@@ -1,12 +1,33 @@
 package com.newspeed.newspeed.domain.friendships.repository;
 
+import com.newspeed.newspeed.domain.friendships.dto.response.FriendSummary;
+import com.newspeed.newspeed.domain.friendships.dto.response.GetFriendShipsResponse;
 import com.newspeed.newspeed.domain.friendships.entity.Friendship;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface FriendshipRepository extends JpaRepository<Friendship,Long> {
-    @Query("SELECT f FROM Friendship f WHERE f.followFrom.id = :userId AND f.followTo.id = :friendId")
+    @Query("SELECT f FROM Friendship f WHERE f.followFrom.userId = :userId AND f.followTo.userId = :friendId")
     Optional<Friendship> findByUserAndFriendId(Long userId, Long friendId);
+
+    @Query("""
+                SELECT new com.newspeed.newspeed.domain.friendships.dto.response.FriendSummary(
+                    CASE 
+                        WHEN f.followFrom.userId = :userId THEN f.followTo.userId
+                        ELSE f.followFrom.userId
+                    END,
+                    CASE 
+                        WHEN f.followFrom.userId = :userId THEN f.followTo.name
+                        ELSE f.followFrom.name
+                    END
+                )
+                FROM Friendship f
+                WHERE f.status = 'ACCEPTED'
+                  AND (f.followFrom.userId = :userId OR f.followTo.userId = :userId)
+            """)
+    Page<FriendSummary> findAcceptedByConditions(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/service/FriendShipService.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/service/FriendShipService.java
@@ -1,0 +1,48 @@
+package com.newspeed.newspeed.domain.friendships.service;
+
+import com.newspeed.newspeed.domain.friendships.dto.request.SendFriendShipRequest;
+import com.newspeed.newspeed.domain.friendships.entity.Friendship;
+import com.newspeed.newspeed.domain.friendships.entity.value.Status;
+import com.newspeed.newspeed.domain.friendships.repository.FriendshipRepository;
+import com.newspeed.newspeed.domain.users.entity.User;
+import com.newspeed.newspeed.domain.users.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FriendShipService {
+
+    private final FriendshipRepository friendShipRepository;
+    private final UserRepository userRepository;
+
+    public void sendRequest(SendFriendShipRequest request, Long userId) {
+        Optional<User> user = userRepository.findById(userId);
+        Optional<User> friend = userRepository.findById(request.targetUserId());
+
+        if (user.isEmpty()) {
+            throw new IllegalArgumentException("존재하지 않는 유저 ID 입니다.");
+        }
+
+        if (friend.isEmpty()) {
+            throw new IllegalArgumentException("존재하지 않는 친구 ID 입니다.");
+        }
+
+        Optional<Friendship> friendship = friendShipRepository.findByUserAndFriendId(userId, request.targetUserId());
+        if(friendship.isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 친구 요청입니다. (상태: " +friendship.get().getStatus() +")");
+        }
+
+        Friendship newFriendship = Friendship.builder()
+                .followFrom(user.get())
+                .followTo(friend.get())
+                .status(Status.PENDING)
+                .build();
+
+        friendShipRepository.save(newFriendship);
+    }
+}

--- a/src/main/java/com/newspeed/newspeed/domain/friendships/service/FriendShipService.java
+++ b/src/main/java/com/newspeed/newspeed/domain/friendships/service/FriendShipService.java
@@ -3,6 +3,7 @@ package com.newspeed.newspeed.domain.friendships.service;
 import com.newspeed.newspeed.domain.friendships.dto.request.HandleFriendShipRequest;
 import com.newspeed.newspeed.domain.friendships.dto.request.SendFriendShipRequest;
 import com.newspeed.newspeed.domain.friendships.dto.response.FriendSummary;
+import com.newspeed.newspeed.domain.friendships.dto.response.GetFriendShipRequestsResponse;
 import com.newspeed.newspeed.domain.friendships.dto.response.GetFriendShipsResponse;
 import com.newspeed.newspeed.domain.friendships.entity.Friendship;
 import com.newspeed.newspeed.domain.friendships.entity.value.Status;
@@ -67,6 +68,17 @@ public class FriendShipService {
         Page<FriendSummary> page = friendShipRepository.findAcceptedByConditions(userId, pageable);
 
         return GetFriendShipsResponse.builder()
+                .friends(page.getContent())
+                .totalPageCount(page.getTotalPages())
+                .totalElementCount(page.getTotalElements())
+                .build();
+    }
+
+    public GetFriendShipRequestsResponse getFriendshipRequests(Long userId, Pageable pageable) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저 ID 입니다."));
+        Page<FriendSummary> page = friendShipRepository.findPendingByConditions(userId, pageable);
+
+        return GetFriendShipRequestsResponse.builder()
                 .friends(page.getContent())
                 .totalPageCount(page.getTotalPages())
                 .totalElementCount(page.getTotalElements())

--- a/src/main/java/com/newspeed/newspeed/domain/users/entity/User.java
+++ b/src/main/java/com/newspeed/newspeed/domain/users/entity/User.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter

--- a/src/main/java/com/newspeed/newspeed/domain/users/entity/User.java
+++ b/src/main/java/com/newspeed/newspeed/domain/users/entity/User.java
@@ -1,0 +1,36 @@
+package com.newspeed.newspeed.domain.users.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "User")
+@Data
+@NoArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "email", nullable = false, unique = true, length = 255)
+    private String email;
+
+    @Column(name = "password", nullable = false, length = 255)
+    private String password;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/newspeed/newspeed/domain/users/entity/User.java
+++ b/src/main/java/com/newspeed/newspeed/domain/users/entity/User.java
@@ -1,36 +1,34 @@
 package com.newspeed.newspeed.domain.users.entity;
 
+import com.newspeed.newspeed.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.Data;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "User")
-@Data
-@NoArgsConstructor
-public class User {
+@Getter
+@Table(name = "user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long userId;
 
-    @Column(name = "name", nullable = false, length = 255)
+    @Column(name="name", nullable = false, length = 255)
     private String name;
 
-    @Column(name = "email", nullable = false, unique = true, length = 255)
+    @Column(name="email", nullable = false, unique = true, length = 255)
     private String email;
 
-    @Column(name = "password", nullable = false, length = 255)
+    @Column(name="password", nullable = false, length = 255)
     private String password;
 
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    @Builder
+    public User(String name, String email, String password){
+        this.name = name;
+        this.email = email;
+        this.password = password;
+    }
 }

--- a/src/main/java/com/newspeed/newspeed/domain/users/entity/Users.java
+++ b/src/main/java/com/newspeed/newspeed/domain/users/entity/Users.java
@@ -1,4 +1,0 @@
-package com.newspeed.newspeed.domain.users.entity;
-
-public class Users {
-}

--- a/src/main/java/com/newspeed/newspeed/domain/users/repository/UserRepository.java
+++ b/src/main/java/com/newspeed/newspeed/domain/users/repository/UserRepository.java
@@ -1,4 +1,10 @@
 package com.newspeed.newspeed.domain.users.repository;
 
-public interface UserRepository {
+import com.newspeed.newspeed.domain.users.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findById(Long id);
 }

--- a/src/main/java/com/newspeed/newspeed/domain/users/repository/UserRepository.java
+++ b/src/main/java/com/newspeed/newspeed/domain/users/repository/UserRepository.java
@@ -2,9 +2,9 @@ package com.newspeed.newspeed.domain.users.repository;
 
 import com.newspeed.newspeed.domain.users.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findById(Long id);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #7 

---

## ✨ 기능 요약
|------|------|
| 🆕 친구 요청 기능 | 다른 유저에게 친구를 신청할 수 있는 기능 |
| 🆕 친구 요청 수락/거절 기능 | 나에게 들어온 요청을 수락하거나 거절할 수 있는 기능 |
| 🆕 친구 목록 조회 기능 | 나와 친구인 유저의 목록을 조회할 수 있는 기능 |
| 🆕 친구 요청 목록 조회 기능 | 나에게 들어온 요청을 조회할 수 있는 기능 |
| 🛠️ 변경사항 예정 | userId를 수동으로 주입하는 것을 세션으로 교체 |
| 🛠️ 변경사항 예정 | 의도적으로 발생시키는 예외를 CustomException으로 교체 |

---

## 🙋‍♀️ 리뷰어 참고사항
<!-- 
- 테스트 방법
- 주요 로직 설명
- 리뷰 시 중점적으로 봐주셨으면 하는 부분
- 코드 스타일 관련 사항 등
--> 

포스트맨으로 테스트는 모두 완료했습니다. 시간이 없어서 포스트맨 캡처는 하지 못했습니다.
이후에는 실시간 알림과 성능 향상을 위한 인덱스를 도입해볼 예정입니다.
